### PR TITLE
fix self-hosted

### DIFF
--- a/app/bitwarden_event_logs/appserver/static/javascript/views/setup_page.js
+++ b/app/bitwarden_event_logs/appserver/static/javascript/views/setup_page.js
@@ -56,8 +56,8 @@ export async function perform(splunk_js_sdk, setup_options) {
 
         // Update script.conf
         const isBitwardenCloud = serverUrl === "https://bitwarden.com" || serverUrl === "bitwarden.com";
-        const apiUrl = isBitwardenCloud ? "https://api.bitwarden.com" : serverUrl + "/api";
-        const identityUrl = isBitwardenCloud ? "https://identity.bitwarden.com" : serverUrl + "/identity";
+        const apiUrl = isBitwardenCloud ? "https://api.bitwarden.com" : serverUrl + "/api/";
+        const identityUrl = isBitwardenCloud ? "https://identity.bitwarden.com" : serverUrl + "/identity/";
         await Splunk.update_configuration_file(
             service,
             "script",


### PR DESCRIPTION
Added a trailing forward-slash to `api` and `identity` URLs. Without it, Splunk tries to hit `/identityconnect/token` instead of `identity/connect/token` when authenticating on self-hosted Bitwarden instances.

