### PR TITLE
server url must be secure

### DIFF
--- a/globalConfig.json
+++ b/globalConfig.json
@@ -23,7 +23,7 @@
     "meta": {
         "name": "bitwarden_event_logs_beta",
         "restRoot": "bitwarden_event_logs",
-        "version": "1.2.0",
+        "version": "1.2.1",
         "displayName": "Bitwarden Event Logs (beta)",
         "schemaVersion": "0.0.3",
         "_uccVersion": "5.41.0"

--- a/package/appserver/static/javascript/views/app.js
+++ b/package/appserver/static/javascript/views/app.js
@@ -70,6 +70,7 @@ define(["react", "splunkjs/splunk"], function(react, splunk_js_sdk){
               ),
             ]),
             e("h3", null, "Self-hosted Bitwarden servers may need to reconfigure their installation's URL."),
+            e("h4", null, "Insecure urls starting with 'http://' are not allowed, use 'https://' instead."),
             e("label", null, [
               "Server URL ",
               e("br"),

--- a/package/appserver/static/javascript/views/app.js
+++ b/package/appserver/static/javascript/views/app.js
@@ -70,7 +70,7 @@ define(["react", "splunkjs/splunk"], function(react, splunk_js_sdk){
               ),
             ]),
             e("h3", null, "Self-hosted Bitwarden servers may need to reconfigure their installation's URL."),
-            e("h4", null, "Insecure urls starting with 'http://' are not allowed, use 'https://' instead."),
+            e("h4", null, "URLs starting with 'http://' is considered insecure and not allowed in Splunk. Please use 'https://' instead."),
             e("label", null, [
               "Server URL ",
               e("br"),

--- a/package/appserver/static/javascript/views/setup_page.js
+++ b/package/appserver/static/javascript/views/setup_page.js
@@ -54,7 +54,8 @@ export async function perform(splunk_js_sdk, setup_options) {
         );
 
         if (serverUrl.startsWith("http://")) {
-            throw new Error("Insecure urls starting with 'http://' are not allowed, use 'https://' instead.");
+            throw new Error("URLs starting with 'http://' is considered insecure and not allowed in Splunk. " +
+                "Please use 'https://' instead.");
         }
 
         // Update script.conf

--- a/package/appserver/static/javascript/views/setup_page.js
+++ b/package/appserver/static/javascript/views/setup_page.js
@@ -53,6 +53,10 @@ export async function perform(splunk_js_sdk, setup_options) {
             { index: index },
         );
 
+        if (serverUrl.startsWith("http://")) {
+            throw new Error("Insecure urls starting with 'http://' are not allowed, use 'https://' instead.");
+        }
+
         // Update script.conf
         const isBitwardenCloud = serverUrl === "https://bitwarden.com" || serverUrl === "bitwarden.com";
         const apiUrl = isBitwardenCloud ? "https://api.bitwarden.com" : serverUrl + "/api/";

--- a/package/appserver/static/javascript/views/setup_page.js
+++ b/package/appserver/static/javascript/views/setup_page.js
@@ -54,7 +54,7 @@ export async function perform(splunk_js_sdk, setup_options) {
         );
 
         if (serverUrl.startsWith("http://")) {
-            throw new Error("URLs starting with 'http://' is considered insecure and not allowed in Splunk. " +
+            throw new URIError("URLs starting with 'http://' is considered insecure and not allowed in Splunk. " +
                 "Please use 'https://' instead.");
         }
 
@@ -78,7 +78,7 @@ export async function perform(splunk_js_sdk, setup_options) {
         await Config.reload_splunk_app(service, app_name);
         Config.redirect_to_splunk_app_homepage(app_name);
     } catch (error) {
-        console.log('Error:', error);
-        alert('Error:' + error);
+        console.log('Error: ', error);
+        alert('Error: ' + error);
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitwarden_event_logs"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Splunk app for reporting Bitwarden event logs."
 authors = [
     "Bitwarden <hello@bitwarden.com>"

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ from models import (
     BitwardenEventsRequest
 )
 from splunk_api import SplunkApi
-from utils import get_logger, set_logging_level, obj_to_json, app_name
+from utils import get_logger, set_logging_level, obj_to_json, app_name, secure_url
 
 
 class Config:
@@ -87,8 +87,8 @@ class Config:
 
         start_date = datetime_from_str(settings_config.get('startDate', None))
 
-        return SettingsConfig(api_url=api_url,
-                              identity_url=identity_url,
+        return SettingsConfig(api_url=secure_url(api_url),
+                              identity_url=secure_url(identity_url),
                               start_date=start_date,
                               logging_level=settings_config.get('loggingLevel', None))
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,7 +9,10 @@ from solnlib.log import Logs
 
 from mappers import datetime_to_str
 
+from urllib.parse import urlparse
+
 app_name = "bitwarden_event_logs_beta"
+
 
 def read_session_token() -> str:
     session_token = sys.stdin.readline(5000).strip()
@@ -54,3 +57,10 @@ def obj_to_json(obj):
     return json.dumps(obj_dict,
                       default=json_serial,
                       separators=(",", ":"))
+
+
+def secure_url(url: str):
+    result = urlparse(url, scheme='https')
+    if result.scheme == 'http':
+        raise Exception("URL must start with https://")
+    return result.geturl()

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,5 +62,6 @@ def obj_to_json(obj):
 def secure_url(url: str):
     result = urlparse(url, scheme='https')
     if result.scheme == 'http':
-        raise Exception("URL must start with https://")
+        raise Exception("URLs starting with 'http://' is considered insecure and not allowed in Splunk. "
+                        "Please use 'https://' instead.")
     return result.geturl()


### PR DESCRIPTION
Enforce Bitwarden Server Url field to be secure, using _https://_.

This is required for the Splunk Cloud vetting, currently failing on `check_for_insecure_http_calls_in_python` check.

Tested on Splunk Enterprise (on-prem). The UI alerts with error when _http://_ is provided. The backend python script also fails when the server url is set to _http://_. Url set to _https://_ works fine.