### PR TITLE
[AC-2933] [Fix] Support for `bitwarden.eu` cloud

### DIFF
--- a/package/appserver/static/javascript/views/setup_page.js
+++ b/package/appserver/static/javascript/views/setup_page.js
@@ -35,7 +35,10 @@ export async function perform(splunk_js_sdk, setup_options) {
             application_name_space,
         );
 
-        let { clientId, clientSecret, index, serverUrl, startDate, ...properties } = setup_options;
+        let { clientId, clientSecret, index, rawServerUrl, startDate, ...properties } = setup_options;
+
+        // Parse server URL
+        const serverUrl = new URL(rawServerUrl);
 
         // Store secrets
         await StoragePasswords.write_secret(
@@ -59,9 +62,9 @@ export async function perform(splunk_js_sdk, setup_options) {
         }
 
         // Update script.conf
-        const isBitwardenCloud = serverUrl === "https://bitwarden.com" || serverUrl === "bitwarden.com";
-        const apiUrl = isBitwardenCloud ? "https://api.bitwarden.com" : serverUrl + "/api/";
-        const identityUrl = isBitwardenCloud ? "https://identity.bitwarden.com" : serverUrl + "/identity/";
+        const isBitwardenCloud = ["bitwarden.com", "bitwarden.eu"].includes(serverUrl.host);
+        const apiUrl = isBitwardenCloud ? `https://api.${serverUrl.host}` : serverUrl + "/api/";
+        const identityUrl = isBitwardenCloud ? `https://identity.${serverUrl.host}` : serverUrl + "/identity/";
         await Splunk.update_configuration_file(
             service,
             "script",


### PR DESCRIPTION


## 🎟️ Tracking

https://github.com/bitwarden/splunk/issues/56

## 📔 Objective

Support for non-US cloud instances (e.g. `bitwarden.eu`).

Details:
- Parse `serverUrl` as an `URL`
- Use `serverUrl.host` as host value
- Support `bitwarden.com` and `bitwarden.eu` as cloud instances

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
