### PR TITLE
PM-11586: Bitwarden API self-signed certificate fix

### DIFF
--- a/src/bitwarden_api.py
+++ b/src/bitwarden_api.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Dict, Any
 
 import requests
@@ -37,6 +38,18 @@ def _join_urls(base: str, *paths: str):
     return url
 
 
+def _get_custom_ca_certificate_location() -> Optional[str]:
+    if 'SPLUNK_HOME' not in os.environ:
+        return None
+
+    app_cacerts_file = os.path.join(os.environ.get('SPLUNK_HOME'), 'etc', 'auth',
+                                    'bitwarden_event_logs_cacerts.pem')
+    if not os.path.isfile(app_cacerts_file):
+        return None
+
+    return app_cacerts_file
+
+
 class BitwardenApi:
     def __init__(self, api_config: BitwardenApiConfig):
         self.logger = get_logger()
@@ -61,7 +74,8 @@ class BitwardenApi:
         response = requests.post(url,
                                  headers=headers,
                                  data=data,
-                                 timeout=REQUESTS_TIMEOUT)
+                                 timeout=REQUESTS_TIMEOUT,
+                                 verify=_get_custom_ca_certificate_location())
 
         response_dict = self.__get_response_json(response)
 
@@ -117,7 +131,8 @@ class BitwardenApi:
         response = requests.get(url,
                                 headers=headers,
                                 params=query_params,
-                                timeout=REQUESTS_TIMEOUT)
+                                timeout=REQUESTS_TIMEOUT,
+                                verify=_get_custom_ca_certificate_location())
 
         return self.__get_response_json(response)
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11586

## 📔 Objective

Provides ability to verify Bitwarden Server Url with self-signed certificate.
The custom CA certs file will be located in `$SPLUNK_HOME/etc/auth/bitwarden_event_logs_cacerts.pem`. If file does not exist, we use default CA certs location (certifi).
It's then up to the customer's discretion to create and fill in the file with custom (usually self-signed) CA certificate chains in PEM format.

Fixes #62

Other solutions considered:
- Provide a guide for customers to update cacert.pem (certifi) that the app uses. Downsides:
  - Changes lost on app update
- Provide a guide for customers to update cacert.pem (certifi) of the Splunk provided Python executable's packages. Then require the app to use python provided lib (certifi), instead of app provided lib package. Downsides:
  - Splunk Enterprise version dependent (no guarantee if certifi is provided, we can at best assume).
  - Using old version of the library (certifi).
  - Changes potentially lost on splunk update
- Provide an "Upload PEM" file upload in UI. Downsides:
  - Moves the responsibility to update (since certs can have short expiry time) of chained self-signed certs from Infrastructure (usually DevOps), to Splunk Admins.
  - Complex: Need to validate the uploaded file content, to not open a potential attack vector to uploading a custom file that could gain machine access (Risk that the app might not vet on Splunk Cloud ?)
  - Complex: Python app needs to consume the PEM as file, which means every single time the app starts, it needs to read uploaded PEM from Splunk kvstore, store on disk temporarily and use. (which is this PR)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
