### PR TITLE
Fix python 3.10 compatibility, better error handling

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # docker exec -u splunk splunk bash -c "/opt/splunk/bin/splunk remove app bitwarden_event_logs_beta -auth admin:password"
 

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 VERSION=$(poetry version | awk -F ' ' '{print $2}')
 APP_NAME="bitwarden_event_logs_beta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["splunk", "bitwarden"]
 
 [tool.poetry.dependencies]
-python = ">=3.7.17, <=3.10"
+python = ">=3.7.17, <3.11"
 requests = "2.31.0"
 splunk-sdk = "2.0.2"
 splunktaucclib = { version = "6.3.0", python = "^3.7" }
@@ -22,7 +22,7 @@ python-dateutil = "2.9.0.post0"
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-python = ">=3.7, <=3.10"
+python = ">=3.7, <3.11"
 python-dotenv = "0.21.1"
 types-requests = "2.31.0.6"
 splunk-add-on-ucc-framework = { version = "5.49.0", python = "^3.7" }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Bring the repo in line with contributing docs:
- Poetry errors when python 3.10 is used, even though it's mentioned as supported in contributing docs. This is likely a poetry exact version matching issue, where `3.10` is treated as `3.10.0`, so using `3.10.1` does not match the `<=3.10` rule.
- package.sh and deploy.sh does not fail on error.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
