### PR TITLE
[PM-26042] Add secretId and serviceAccountId to BitwardenEvents model

### DIFF
--- a/src/mappers.py
+++ b/src/mappers.py
@@ -34,7 +34,9 @@ def get_bitwarden_event(data: Dict[str, Any]):
                           memberId=data.get("memberId", None),
                           actingUserId=data.get("actingUserId", None),
                           device=device,
-                          ipAddress=data.get("ipAddress", None))
+                          ipAddress=data.get("ipAddress", None),
+                          secretId=data.get("secretId", None),
+                          serviceAccountId=data.get("serviceAccountId", None))
 
 
 def get_bitwarden_group(data: Dict[str, Any]):

--- a/src/models.py
+++ b/src/models.py
@@ -44,7 +44,8 @@ class BitwardenEvent:
     actingUserId: Optional[str]
     device: Optional[int]
     ipAddress: Optional[str]
-
+    secretId: Optional[str]
+    serviceAccountId: Optional[str]
 
 @dataclass
 class BitwardenEnhancedEvent(BitwardenEvent):


### PR DESCRIPTION
## 🎟️ Tracking

Hi,

This PR goes along with issue https://github.com/bitwarden/splunk/issues/110

## 📔 Objective

The purpose of this PR is to add the secretId and serviceAccountId attributes to the BitwardenEvents model.  Without these attributes, events from the Secrets Manager only contain the client IP address and type. It would be helpful to know which secret is being accessed and by which service/machine account. 

This is my first time submitting a PR to this project (or any Bitwarden project for that matter). I went through the Contributing setup and verified I can install the app with these changes. If there is anything I am missing please let me know.

Thanks for taking a look, I appreciate it!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
