### PR TITLE
[PM-28841] Fix infinite loop in event query

### DIFF
--- a/src/bitwarden_api.py
+++ b/src/bitwarden_api.py
@@ -99,8 +99,13 @@ class BitwardenApi:
 
         data = [get_bitwarden_event(item_dict) for item_dict in response_dict.get("data", [])]
 
-        return BitwardenEventsResponse(data=data,
-                                       continuationToken=response_dict.get("continuationToken", None))
+        # The Bitwarden API may return an empty string for the continuationToken
+        # when there are no more pages. Normalize this to "None" to ensure it is
+        # handled properly.
+        return BitwardenEventsResponse(
+            data=data,
+            continuationToken=response_dict.get("continuationToken", None) or None
+        )
 
     def get_groups(self):
         url = _join_urls(self.api_config.events_api_url, "/public/groups")


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28841

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
While testing Splunk, I noticed it was getting stuck in an infinite loop pulling the same 2 events down over and over. These duplicated and stacked up in Splunk (e.g. 1 login event turned into 3000 logins). This turned out to be a bug in how we’re handling the continuationToken in the Splunk app.

Per Claude (verified by me):
> **Root Cause Analysis**
> 
>  The infinite loop occurs because of improper handling of empty string continuation tokens from the Bitwarden API.
> 
>  **The Problem**
> 
>  In src/bitwarden_api.py:103, the continuation token is extracted as:
>  continuationToken=response_dict.get("continuationToken", None)
> 
>  If the Bitwarden API returns an empty string ("") instead of omitting the field or setting it to null, the 
>  following happens:
> 
>  1. Empty string is not None: In Python, "" is not None evaluates to True
>  2. Loop doesn't exit: The break condition in src/event_logs.py:51 checks if events_response.continuationToken is 
>  None, which fails for empty strings
>  3. Same events repeated: The next API call includes continuationToken="" in query params, which the API likely 
>  ignores, returning the first page again
>  4. Infinite loop: The cycle repeats forever with the same events

The fix is to normalize empty strings to `None` when pulling events, ensuring that the loop exit condition is hit.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
