### PR TITLE
[PM-37233] Set python.required to 3.13 in scripted input

### DIFF
--- a/package/default/inputs.conf
+++ b/package/default/inputs.conf
@@ -4,3 +4,4 @@ sourcetype = bitwarden:events
 index = main
 passAuth = splunk-system-user
 python.version = python3
+python.required = 3.13


### PR DESCRIPTION
merge after app update to python 3.13 #200 

## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-37233

## 📔 Objective
Splunk apps will soon be required to set the required python version with `python.required` in inputs.conf files. This updates our app to set `3.13` as the default version.