### PR TITLE
[PM-36837] Add event_delivery_mode setting to script configuration 

### DIFF
--- a/package/README/script.conf.spec
+++ b/package/README/script.conf.spec
@@ -3,3 +3,4 @@ apiUrl=
 identityUrl=
 startDate=
 loggingLevel=
+eventDeliveryMode=

--- a/package/default/script.conf
+++ b/package/default/script.conf
@@ -2,3 +2,4 @@
 apiUrl=https://api.bitwarden.com
 identityUrl=https://identity.bitwarden.com
 loggingLevel=INFO
+eventDeliveryMode=poll

--- a/src/bitwarden_event_logs.py
+++ b/src/bitwarden_event_logs.py
@@ -41,6 +41,10 @@ class App:
         return EventLogsWriter(self.bitwarden_api, self.checkpoint, self.settings_config)
 
     def run(self):
+        if self.settings_config.event_delivery_mode == 'push':
+            self.logger.info('using push event delivery mode, no polling necessary. exiting.')
+            return
+
         for next_request, events in self.event_logs_writer.read_events():
             self.event_logs_writer.write_events(events)
 

--- a/src/config.py
+++ b/src/config.py
@@ -84,11 +84,13 @@ class Config:
         identity_url = identity_url.strip(" \"")
 
         start_date = datetime_from_str(settings_config.get('startDate', None))
+        event_delivery_mode = settings_config.get('eventDeliveryMode', 'poll')
 
         return SettingsConfig(api_url=secure_url(api_url),
                               identity_url=secure_url(identity_url),
                               start_date=start_date,
-                              logging_level=settings_config.get('loggingLevel', None))
+                              logging_level=settings_config.get('loggingLevel', None),
+                              event_delivery_mode=event_delivery_mode)
 
     @classmethod
     def __parse_bitwarden_api_key(cls, bitwarden_api_key: Optional[str]) -> BitwardenApiKey:

--- a/src/models.py
+++ b/src/models.py
@@ -9,6 +9,7 @@ class SettingsConfig:
     identity_url: str
     start_date: Optional[datetime] = None
     logging_level: Optional[str] = None
+    event_delivery_mode: str = 'poll'
 
 
 @dataclass


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-36837

## 📔 Objective
With changes coming up to allow Bitwarden Organization Event data to be received via Splunk's HTTP Event Collector (HEC), a new configuration flag is needed to disable old polling configurations in favor of new push based configurations.

A new `event_delivery_mode` property is added to the existing config settings used by the python script. When the property is set to `push`, the python script will now exit early and no polling of Bitwarden APIs will occur. This is because `push` configurations will receive the event data instead through HEC.

## Screenshot
**`event_delivery_mode=poll` set in script.conf exits the python script early**

<img width="1279" height="77" alt="image" src="https://github.com/user-attachments/assets/e93203b1-2e0e-4018-9b05-651ea4c3cae6" />
